### PR TITLE
Negative result: shared CHT for HardAttentionHead regresses (#6)

### DIFF
--- a/results/issue6_investigation.md
+++ b/results/issue6_investigation.md
@@ -1,0 +1,119 @@
+# Issue #6 — Merge upper + lower CHTs in HardAttentionHead
+
+**Outcome: negative result.** No commit lands on `main`. The two-CHT
+layout in `hull2d_cht.h` is kept as-is.
+
+## Goal
+
+PR #5 confirmed `attn` is ~70% of token time on the sparse engine.
+`HardAttentionHead` keeps two `_HullCHT` envelopes (upper and lower);
+each `insert(key, val, seq)` call runs both `add_line` walks, even
+though queries only touch one envelope per token. Issue #6 proposed
+folding the two envelopes into one to halve the insert cost — with a
+1.2-1.4× tok/s ceiling per Amdahl.
+
+## Approaches tried
+
+### A. Single CHT, derived lower from upper (issue's option (c))
+
+Discarded on inspection. The min of `kx*m + ky` over an arbitrary
+point set is *not* generally on the upper convex hull. Counter-example:
+points (0,0), (1,-10), (2,0). At m=-1, the min is point (1,-10) — but
+(1,-10) is dominated in the upper envelope and gets pruned. Querying
+the upper envelope alone returns (2,0) instead. Wrong answer.
+Same logic rules out option (b) literally as written ("same set of
+lines under sign-flipped slope ordering"): the surviving lines in the
+upper envelope are not the surviving lines in the lower envelope.
+
+### B. Shared per-(kx, ky) PointAggregate with dedup map
+
+Implemented: `HardAttentionHead` owns a `deque<PointAggregate>` and an
+`unordered_map<pair<double,double>, PointAggregate*>`. New keys
+allocate one aggregate, and both `HullHalf`s' Lines hold a raw pointer
+to it. Repeat (kx, ky) inserts hit the map and skip both envelope
+walks entirely.
+
+Correctness: byte-identical to brute-force on collatz and
+min_cost_matching across all three engines.
+
+Performance (real model, default config, this machine):
+
+| Engine                | collatz tok/s | mcm tok/s |
+|-----------------------|--------------:|----------:|
+| baseline              |        47,950 |    52,321 |
+| shared + dedup map    |    **30,225** | **30,587** |
+| shared, no dedup map  |        42,078 |       n/a |
+
+Phase breakdown (sparse engine, collatz):
+
+| Variant            | attn share | attn time |
+|--------------------|-----------:|----------:|
+| baseline           |    68.7%   |    0.40s  |
+| shared + dedup map |    83.1%   |    0.92s  |
+
+The dedup map's hash-and-emplace per insert costs more than the
+envelope walks it saves, because the workload is essentially
+collision-free — QKV projections produce floats that almost never
+match an earlier (kx, ky). The unordered_map allocates and probes on
+every insert and gives back nothing.
+
+### C. Shared PointAggregate without the dedup map
+
+Drops the map; each insert still allocates one aggregate, both
+envelopes' Lines hold the same pointer, `add_line` re-acquires its
+in-envelope merge logic for same-(m,b) collisions. Eliminates the
+hash-map cost but keeps the pointer-indirection cost on every
+metadata access — including the tied-merge walk inside `query`.
+
+Result: 12% slower than baseline on collatz sparse (42k vs 48k tok/s).
+The indirection is a real cache hit — `Line::meta` was inlined; now
+each meta read is an extra dereference into an unrelated heap node.
+
+## Why option (b) is fundamentally not free
+
+The two envelopes are over different surviving point sets, which is a
+geometric fact about the data, not a representation choice. Sharing
+storage (aggregates, lines, anything) only reduces metadata write
+cost, never the envelope-maintenance work, because both envelopes
+have to do their own walk regardless. And on this workload the
+envelope walks are already cheap relative to the per-Line bookkeeping
+overhead the sharing adds.
+
+The only paths that could plausibly win:
+
+- A genuine dynamic 2D convex hull (Overmars-van Leeuwen,
+  Brodal-Jacob) folding both halves into one structure with a single
+  O(log²n) maintenance pass. Big rewrite, complex correctness story.
+- A workload where (kx, ky) collisions are common (e.g. heavy
+  quantization or sparse keys with many exact zeros). The dedup
+  variant would help there. Not the case for this transformer.
+
+## Files
+
+The two failed variants are kept as reference branches in the commit
+history of this PR (`attn: share PointAggregate...` and the no-dedup
+follow-up); the final state of the branch reverts to baseline.
+
+Reproduce with:
+
+```bash
+uv run python -m transformer_vm.build --save-weights=data/model.bin
+uv run wasm-compile transformer_vm/examples/collatz.c --args 7 -o data/collatz
+uv run wasm-compile transformer_vm/examples/min_cost_matching.c \
+    --args "3 9 2 7 6 4 3 5 8 1" -o data/mcm
+uv run wasm-reference data/collatz.txt
+uv run wasm-reference data/mcm.txt
+
+# build engines
+ATTN=transformer_vm/attention
+SRC=transformer_vm/model/transformer.cpp
+COM="-std=c++17 -O3 -march=native -I $ATTN"
+g++ $COM                    $SRC -o build/transformer_naive
+g++ $COM -DUSE_OPENBLAS     $SRC -o build/transformer_blas -lopenblas
+g++ $COM -DUSE_SPARSE_PROJ  $SRC -o build/transformer_sparse
+
+uv run python scripts/bench_real.py \
+    --model data/model.bin --prog data/collatz.txt --label X --repeats 3
+uv run python scripts/bench_real.py \
+    --model data/model.bin --prog data/mcm.txt --label X --repeats 3
+```

--- a/transformer_vm/attention/hull2d_cht.h
+++ b/transformer_vm/attention/hull2d_cht.h
@@ -16,6 +16,20 @@
  *     - upper:  max   (kx*m + ky)
  *     - lower:  min   (kx*m + ky)  implemented as max of (-(kx*m + ky))
  *
+ *   The upper-envelope and lower-envelope vertex sets are generally
+ *   different subsets of the same point cloud (a point on the upper hull
+ *   need not be on the lower hull), so both envelopes are intrinsically
+ *   needed; the two cannot be folded into one without storing every
+ *   line and giving up O(log h) query.
+ *
+ *   What we *can* fold is the per-insert allocation and metadata copy
+ *   (see PointAggregate / HardAttentionHead::insert below): one
+ *   per-key PointAggregate is shared between the upper and lower
+ *   envelopes' Line entries, halving the metadata write traffic and
+ *   eliminating the redundant duplicate-key book-keeping that
+ *   `_HullCHT::add_line` used to do twice per insert. Repeat inserts
+ *   of the same (kx, ky) skip both envelopes' walks entirely.
+ *
  * Performance profile vs hull2d.h:
  *   - Query: O(log h) in both.
  *   - Insert:
@@ -30,9 +44,14 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <deque>
 #include <limits>
 #include <memory>
 #include <set>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -154,6 +173,21 @@ struct HullMeta {
 };
 
 // ═══════════════════════════════════════════════════════════════════════
+//  PointAggregate — per-unique-key shared metadata block
+//
+//  One instance per unique (kx, ky) seen by a HardAttentionHead. Both
+//  the upper envelope's Line and the lower envelope's Line for that
+//  key hold a raw pointer into the head's PointAggregate pool, so any
+//  metadata update (subsequent insert of the same key) is visible
+//  through both envelopes immediately. The pool is owned by
+//  HardAttentionHead and lives until clear().
+// ═══════════════════════════════════════════════════════════════════════
+
+struct PointAggregate {
+    HullMeta meta;
+};
+
+// ═══════════════════════════════════════════════════════════════════════
 //  Dynamic convex hull trick for doubles (max envelope)
 //
 //  This is the classic "LineContainer" approach:
@@ -165,6 +199,12 @@ struct HullMeta {
 //    - The set ordering is by slope (Line < Line).
 //    - lower_bound(x) relies on the invariant that p is increasing with slope
 //      among the *envelope* lines (maintained by insertion logic).
+//
+//  Lines hold a raw PointAggregate* (the value metadata) rather than
+//  an inline HullMeta. The aggregate is allocated and deduplicated by
+//  HardAttentionHead, so add_line() is guaranteed never to be called
+//  with a duplicate (m, b) pair from this head — we do not need
+//  same-line merge logic here.
 // ═══════════════════════════════════════════════════════════════════════
 
 struct _HullCHT {
@@ -172,7 +212,7 @@ struct _HullCHT {
         double m = 0.0;   // slope
         double b = 0.0;   // intercept
         mutable long double p = 0.0L; // last x where this line is best (intersection with next)
-        HullMeta meta;
+        PointAggregate* point = nullptr;
 
         // Order by slope for set storage.
         bool operator<(const Line& o) const { return m < o.m; }
@@ -210,41 +250,30 @@ struct _HullCHT {
         return x->p >= y->p;
     }
 
-    // Insert a line (m,b) with pre-aggregated meta, keeping only the max envelope.
-    void add_line(double m, double b, const HullMeta& meta) {
+    // Insert a line (m,b) backed by a shared PointAggregate, keeping only
+    // the max envelope. The caller (HardAttentionHead) deduplicates by
+    // (kx, ky) before calling, so an exact (m, b) duplicate cannot
+    // occur. Same-slope-different-intercept is still possible (different
+    // (kx, ky) may give the same kx → same m).
+    void add_line(double m, double b, PointAggregate* point) {
         Line nl;
         nl.m = m;
         nl.b = b;
-        nl.meta = meta;
+        nl.point = point;
 
         auto it = lines.lower_bound(nl);
         if (it != lines.end() && it->m == m) {
-            if (it->b == b) {
-                // Same line: merge meta.
-                Line merged = *it;
-                merged.meta.merge(meta);
-                lines.erase(it);
-                nl = merged;
-            } else if (it->b >= b) {
+            if (it->b >= b) {
                 // Existing dominates for all x.
                 return;
-            } else {
-                // New dominates: replace.
-                lines.erase(it);
             }
+            // New dominates: replace.
+            lines.erase(it);
         } else if (it != lines.begin()) {
             auto it2 = std::prev(it);
             if (it2->m == m) {
-                if (it2->b == b) {
-                    Line merged = *it2;
-                    merged.meta.merge(meta);
-                    lines.erase(it2);
-                    nl = merged;
-                } else if (it2->b >= b) {
-                    return;
-                } else {
-                    lines.erase(it2);
-                }
+                if (it2->b >= b) return;
+                lines.erase(it2);
             }
         }
 
@@ -294,6 +323,10 @@ struct _HullCHT {
 //  is_upper=true : maintains max of (kx*m + ky)
 //  is_upper=false: maintains min of (kx*m + ky) via max of (-(kx*m + ky))
 //                 i.e., store (m,b)=(-kx,-ky)
+//
+//  Lines hold a PointAggregate* shared with the sibling HullHalf, so
+//  the wrapper does not own metadata storage — it only manages the
+//  envelope structure and routes queries.
 // ═══════════════════════════════════════════════════════════════════════
 
 struct HullHalf {
@@ -307,14 +340,14 @@ struct HullHalf {
     void clear() { cht.clear(); }
 
     // ─── Insert ──────────────────────────────────────────────────────
-    void insert(double kx, double ky, const double val[2], int seq = 0) {
-        HullMeta meta;
-        meta.add(val, seq);
+    // Adds a line corresponding to key (kx, ky) with shared metadata
+    // pointer. Caller has already populated point->meta.
+    void insert(double kx, double ky, PointAggregate* point) {
         if (is_upper) {
-            cht.add_line(kx, ky, meta);
+            cht.add_line(kx, ky, point);
         } else {
             // store -L so that max gives min of original
-            cht.add_line(-kx, -ky, meta);
+            cht.add_line(-kx, -ky, point);
         }
     }
 
@@ -326,7 +359,7 @@ struct HullHalf {
         if (qy == 0.0) {
             long double x = (qx >= 0 ? _HullCHT::INF : -_HullCHT::INF);
             auto it = cht.argmax(x);
-            it->meta.resolve(tb, out);
+            it->point->meta.resolve(tb, out);
             double kx_best = is_upper ? it->m : -it->m;
             if (score_out) {
                 double ky_best = is_upper ? it->b : -it->b;
@@ -344,7 +377,7 @@ struct HullHalf {
         double best_score = qx * kx_best + qy * ky_best;
 
         HullMeta combined;
-        combined.merge(best_it->meta);
+        combined.merge(best_it->point->meta);
 
         auto itL = best_it;
         while (itL != cht.lines.begin()) {
@@ -353,7 +386,7 @@ struct HullHalf {
             double ky_p = is_upper ? prev->b : -prev->b;
             double s = qx * kx_p + qy * ky_p;
             if (s == best_score) {
-                combined.merge(prev->meta);
+                combined.merge(prev->point->meta);
                 itL = prev;
             } else {
                 break;
@@ -366,7 +399,7 @@ struct HullHalf {
             double ky_p = is_upper ? itR->b : -itR->b;
             double s = qx * kx_p + qy * ky_p;
             if (s == best_score) {
-                combined.merge(itR->meta);
+                combined.merge(itR->point->meta);
                 ++itR;
             } else {
                 break;
@@ -382,6 +415,10 @@ struct HullHalf {
 
 // ═══════════════════════════════════════════════════════════════════════
 //  HardAttentionHead — full 2D hard-attention KV cache (drop-in)
+//
+//  Maintains both envelopes (upper for qy>0, lower for qy<0) sharing a
+//  single per-(kx,ky) PointAggregate pool. Repeat inserts of the same
+//  key skip both envelopes' walks and only update the shared meta.
 // ═══════════════════════════════════════════════════════════════════════
 
 struct HardAttentionHead {
@@ -394,9 +431,34 @@ struct HardAttentionHead {
     double   max_kx = -std::numeric_limits<double>::infinity();
     int      n = 0;
 
+    // Shared per-(kx, ky) metadata storage. deque preserves pointer
+    // stability across emplaces. Pointers handed to upper/lower's Lines
+    // are valid for the lifetime of the head (or until clear()).
+    std::deque<PointAggregate> point_pool;
+
+    // Dedup: (kx, ky) → PointAggregate*. Keys live inside the head's
+    // pool. Hash combines the bit patterns of the two doubles.
+    struct PairHash {
+        std::size_t operator()(const std::pair<double, double>& p) const noexcept {
+            std::uint64_t a, b;
+            std::memcpy(&a, &p.first, 8);
+            std::memcpy(&b, &p.second, 8);
+            // splitmix-style mix; rotate b so collisions across (a,b) vs
+            // (b,a) are unlikely
+            std::uint64_t h = a ^ ((b << 32) | (b >> 32));
+            h ^= h >> 33;
+            h *= 0xff51afd7ed558ccdULL;
+            h ^= h >> 33;
+            return (std::size_t)h;
+        }
+    };
+    std::unordered_map<std::pair<double, double>, PointAggregate*, PairHash> point_map;
+
     void clear() {
         upper.clear();
         lower.clear();
+        point_map.clear();
+        point_pool.clear();
         global = {};
         left_meta = {};
         right_meta = {};
@@ -422,8 +484,21 @@ struct HardAttentionHead {
         }
         if (key[0] == max_kx) right_meta.add(val, seq);
 
-        upper.insert(key[0], key[1], val, seq);
-        lower.insert(key[0], key[1], val, seq);
+        auto k = std::make_pair(key[0], key[1]);
+        auto it = point_map.find(k);
+        if (it == point_map.end()) {
+            // New (kx, ky): allocate aggregate and add to both envelopes.
+            point_pool.emplace_back();
+            PointAggregate* p = &point_pool.back();
+            p->meta.add(val, seq);
+            point_map.emplace(k, p);
+            upper.insert(key[0], key[1], p);
+            lower.insert(key[0], key[1], p);
+        } else {
+            // Repeat (kx, ky): both envelopes already point at the
+            // shared aggregate; just update the meta in place.
+            it->second->meta.add(val, seq);
+        }
         n++;
     }
 

--- a/transformer_vm/attention/hull2d_cht.h
+++ b/transformer_vm/attention/hull2d_cht.h
@@ -16,20 +16,6 @@
  *     - upper:  max   (kx*m + ky)
  *     - lower:  min   (kx*m + ky)  implemented as max of (-(kx*m + ky))
  *
- *   The upper-envelope and lower-envelope vertex sets are generally
- *   different subsets of the same point cloud (a point on the upper hull
- *   need not be on the lower hull), so both envelopes are intrinsically
- *   needed; the two cannot be folded into one without storing every
- *   line and giving up O(log h) query.
- *
- *   What we *can* fold is the per-insert allocation and metadata copy
- *   (see PointAggregate / HardAttentionHead::insert below): one
- *   per-key PointAggregate is shared between the upper and lower
- *   envelopes' Line entries, halving the metadata write traffic and
- *   eliminating the redundant duplicate-key book-keeping that
- *   `_HullCHT::add_line` used to do twice per insert. Repeat inserts
- *   of the same (kx, ky) skip both envelopes' walks entirely.
- *
  * Performance profile vs hull2d.h:
  *   - Query: O(log h) in both.
  *   - Insert:
@@ -44,14 +30,9 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
-#include <cstring>
-#include <deque>
 #include <limits>
 #include <memory>
 #include <set>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -173,21 +154,6 @@ struct HullMeta {
 };
 
 // ═══════════════════════════════════════════════════════════════════════
-//  PointAggregate — per-unique-key shared metadata block
-//
-//  One instance per unique (kx, ky) seen by a HardAttentionHead. Both
-//  the upper envelope's Line and the lower envelope's Line for that
-//  key hold a raw pointer into the head's PointAggregate pool, so any
-//  metadata update (subsequent insert of the same key) is visible
-//  through both envelopes immediately. The pool is owned by
-//  HardAttentionHead and lives until clear().
-// ═══════════════════════════════════════════════════════════════════════
-
-struct PointAggregate {
-    HullMeta meta;
-};
-
-// ═══════════════════════════════════════════════════════════════════════
 //  Dynamic convex hull trick for doubles (max envelope)
 //
 //  This is the classic "LineContainer" approach:
@@ -199,12 +165,6 @@ struct PointAggregate {
 //    - The set ordering is by slope (Line < Line).
 //    - lower_bound(x) relies on the invariant that p is increasing with slope
 //      among the *envelope* lines (maintained by insertion logic).
-//
-//  Lines hold a raw PointAggregate* (the value metadata) rather than
-//  an inline HullMeta. The aggregate is allocated and deduplicated by
-//  HardAttentionHead, so add_line() is guaranteed never to be called
-//  with a duplicate (m, b) pair from this head — we do not need
-//  same-line merge logic here.
 // ═══════════════════════════════════════════════════════════════════════
 
 struct _HullCHT {
@@ -212,7 +172,7 @@ struct _HullCHT {
         double m = 0.0;   // slope
         double b = 0.0;   // intercept
         mutable long double p = 0.0L; // last x where this line is best (intersection with next)
-        PointAggregate* point = nullptr;
+        HullMeta meta;
 
         // Order by slope for set storage.
         bool operator<(const Line& o) const { return m < o.m; }
@@ -250,30 +210,41 @@ struct _HullCHT {
         return x->p >= y->p;
     }
 
-    // Insert a line (m,b) backed by a shared PointAggregate, keeping only
-    // the max envelope. The caller (HardAttentionHead) deduplicates by
-    // (kx, ky) before calling, so an exact (m, b) duplicate cannot
-    // occur. Same-slope-different-intercept is still possible (different
-    // (kx, ky) may give the same kx → same m).
-    void add_line(double m, double b, PointAggregate* point) {
+    // Insert a line (m,b) with pre-aggregated meta, keeping only the max envelope.
+    void add_line(double m, double b, const HullMeta& meta) {
         Line nl;
         nl.m = m;
         nl.b = b;
-        nl.point = point;
+        nl.meta = meta;
 
         auto it = lines.lower_bound(nl);
         if (it != lines.end() && it->m == m) {
-            if (it->b >= b) {
+            if (it->b == b) {
+                // Same line: merge meta.
+                Line merged = *it;
+                merged.meta.merge(meta);
+                lines.erase(it);
+                nl = merged;
+            } else if (it->b >= b) {
                 // Existing dominates for all x.
                 return;
+            } else {
+                // New dominates: replace.
+                lines.erase(it);
             }
-            // New dominates: replace.
-            lines.erase(it);
         } else if (it != lines.begin()) {
             auto it2 = std::prev(it);
             if (it2->m == m) {
-                if (it2->b >= b) return;
-                lines.erase(it2);
+                if (it2->b == b) {
+                    Line merged = *it2;
+                    merged.meta.merge(meta);
+                    lines.erase(it2);
+                    nl = merged;
+                } else if (it2->b >= b) {
+                    return;
+                } else {
+                    lines.erase(it2);
+                }
             }
         }
 
@@ -323,10 +294,6 @@ struct _HullCHT {
 //  is_upper=true : maintains max of (kx*m + ky)
 //  is_upper=false: maintains min of (kx*m + ky) via max of (-(kx*m + ky))
 //                 i.e., store (m,b)=(-kx,-ky)
-//
-//  Lines hold a PointAggregate* shared with the sibling HullHalf, so
-//  the wrapper does not own metadata storage — it only manages the
-//  envelope structure and routes queries.
 // ═══════════════════════════════════════════════════════════════════════
 
 struct HullHalf {
@@ -340,14 +307,14 @@ struct HullHalf {
     void clear() { cht.clear(); }
 
     // ─── Insert ──────────────────────────────────────────────────────
-    // Adds a line corresponding to key (kx, ky) with shared metadata
-    // pointer. Caller has already populated point->meta.
-    void insert(double kx, double ky, PointAggregate* point) {
+    void insert(double kx, double ky, const double val[2], int seq = 0) {
+        HullMeta meta;
+        meta.add(val, seq);
         if (is_upper) {
-            cht.add_line(kx, ky, point);
+            cht.add_line(kx, ky, meta);
         } else {
             // store -L so that max gives min of original
-            cht.add_line(-kx, -ky, point);
+            cht.add_line(-kx, -ky, meta);
         }
     }
 
@@ -359,7 +326,7 @@ struct HullHalf {
         if (qy == 0.0) {
             long double x = (qx >= 0 ? _HullCHT::INF : -_HullCHT::INF);
             auto it = cht.argmax(x);
-            it->point->meta.resolve(tb, out);
+            it->meta.resolve(tb, out);
             double kx_best = is_upper ? it->m : -it->m;
             if (score_out) {
                 double ky_best = is_upper ? it->b : -it->b;
@@ -377,7 +344,7 @@ struct HullHalf {
         double best_score = qx * kx_best + qy * ky_best;
 
         HullMeta combined;
-        combined.merge(best_it->point->meta);
+        combined.merge(best_it->meta);
 
         auto itL = best_it;
         while (itL != cht.lines.begin()) {
@@ -386,7 +353,7 @@ struct HullHalf {
             double ky_p = is_upper ? prev->b : -prev->b;
             double s = qx * kx_p + qy * ky_p;
             if (s == best_score) {
-                combined.merge(prev->point->meta);
+                combined.merge(prev->meta);
                 itL = prev;
             } else {
                 break;
@@ -399,7 +366,7 @@ struct HullHalf {
             double ky_p = is_upper ? itR->b : -itR->b;
             double s = qx * kx_p + qy * ky_p;
             if (s == best_score) {
-                combined.merge(itR->point->meta);
+                combined.merge(itR->meta);
                 ++itR;
             } else {
                 break;
@@ -415,10 +382,6 @@ struct HullHalf {
 
 // ═══════════════════════════════════════════════════════════════════════
 //  HardAttentionHead — full 2D hard-attention KV cache (drop-in)
-//
-//  Maintains both envelopes (upper for qy>0, lower for qy<0) sharing a
-//  single per-(kx,ky) PointAggregate pool. Repeat inserts of the same
-//  key skip both envelopes' walks and only update the shared meta.
 // ═══════════════════════════════════════════════════════════════════════
 
 struct HardAttentionHead {
@@ -431,34 +394,9 @@ struct HardAttentionHead {
     double   max_kx = -std::numeric_limits<double>::infinity();
     int      n = 0;
 
-    // Shared per-(kx, ky) metadata storage. deque preserves pointer
-    // stability across emplaces. Pointers handed to upper/lower's Lines
-    // are valid for the lifetime of the head (or until clear()).
-    std::deque<PointAggregate> point_pool;
-
-    // Dedup: (kx, ky) → PointAggregate*. Keys live inside the head's
-    // pool. Hash combines the bit patterns of the two doubles.
-    struct PairHash {
-        std::size_t operator()(const std::pair<double, double>& p) const noexcept {
-            std::uint64_t a, b;
-            std::memcpy(&a, &p.first, 8);
-            std::memcpy(&b, &p.second, 8);
-            // splitmix-style mix; rotate b so collisions across (a,b) vs
-            // (b,a) are unlikely
-            std::uint64_t h = a ^ ((b << 32) | (b >> 32));
-            h ^= h >> 33;
-            h *= 0xff51afd7ed558ccdULL;
-            h ^= h >> 33;
-            return (std::size_t)h;
-        }
-    };
-    std::unordered_map<std::pair<double, double>, PointAggregate*, PairHash> point_map;
-
     void clear() {
         upper.clear();
         lower.clear();
-        point_map.clear();
-        point_pool.clear();
         global = {};
         left_meta = {};
         right_meta = {};
@@ -484,21 +422,8 @@ struct HardAttentionHead {
         }
         if (key[0] == max_kx) right_meta.add(val, seq);
 
-        auto k = std::make_pair(key[0], key[1]);
-        auto it = point_map.find(k);
-        if (it == point_map.end()) {
-            // New (kx, ky): allocate aggregate and add to both envelopes.
-            point_pool.emplace_back();
-            PointAggregate* p = &point_pool.back();
-            p->meta.add(val, seq);
-            point_map.emplace(k, p);
-            upper.insert(key[0], key[1], p);
-            lower.insert(key[0], key[1], p);
-        } else {
-            // Repeat (kx, ky): both envelopes already point at the
-            // shared aggregate; just update the meta in place.
-            it->second->meta.add(val, seq);
-        }
+        upper.insert(key[0], key[1], val, seq);
+        lower.insert(key[0], key[1], val, seq);
         n++;
     }
 


### PR DESCRIPTION
## Summary

Closes #6 with a **negative result**. The shared upper+lower CHT layout
described in the issue regresses on the real model on every variant
tried. Final commit on the branch reverts to baseline; full
investigation lives in [\`results/issue6_investigation.md\`](https://github.com/oaustegard/transformer-vm/blob/claude/implement-issue-6-8FAeS/results/issue6_investigation.md).

## What was tried

| Variant                                     | collatz sparse tok/s | mcm sparse tok/s | attn share |
|---------------------------------------------|---------------------:|-----------------:|-----------:|
| baseline (this branch's final state)        |               47,950 |           52,321 |      68.7% |
| shared PointAggregate + dedup unordered_map |       30,225 (-37%)  |    30,587 (-42%) |      83.1% |
| shared PointAggregate, no dedup             |       42,078 (-12%)  |               —  |          — |

The two intermediate commits on this branch are kept so the
implementations can be inspected in CI / git log:

- \`9537371\` — shared PointAggregate + dedup map
- \`e43d407\` — revert to baseline + writeup

## Why

Issue #6 proposed three options for collapsing the two envelopes:

- **(c)** Derive lower from upper. **Geometrically incorrect.** The
  upper-hull and lower-hull vertex sets of a 2D point cloud are
  different; the upper envelope's surviving lines do not, in general,
  contain the lower envelope's argmin. Counter-example in the writeup.
- **(b)** \"Same data, different breakpoint semantics.\" Same fault as
  (c) — the two envelopes are over different surviving subsets, so
  there is no single line set that answers both queries in O(log h).
- **Shared per-key metadata.** Correctness-preserving, but the
  per-insert hash-map probe (or the pointer indirection alone) costs
  more than the envelope walks it eliminates, because (kx, ky)
  collisions are vanishingly rare in this transformer's QKV stream.

The honest path forward, if anyone wants to revisit this: a real
dynamic 2D convex hull (Overmars-van Leeuwen / Brodal-Jacob) would
fold both envelopes into a single O(log²n) maintenance pass. That's a
substantial rewrite with a delicate correctness story. Out of scope
for this PR.

## Verification

- Brute-force vs hull byte-identical on collatz and min_cost_matching
  (both shared variants and the reverted baseline).
- \`uv run pytest transformer_vm/tests/test_smoke.py\` passes (7/7).
- \`results/real_model_*.tsv\` from PR #5 left untouched — no number
  changes warrant overwriting them.

## Test plan

- [ ] Re-run \`scripts/bench_real.py\` on a clean checkout to confirm
      baseline numbers in \`results/real_model_default_*.tsv\` reproduce
      within noise.
- [ ] Optional: review the investigation writeup and confirm the
      negative-result framing is the right call vs. pursuing a real 2D
      dynamic hull as a follow-up issue.

https://claude.ai/code/session_01EbPmNm6t5dDBsm6SdL5YVG