### PR TITLE
Decision-boundary divergence horizon — characterize FP drift (#10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,21 @@ all:     default blas
 $(BUILD):
 	@mkdir -p $@
 
+# On Linux, libraries must follow their users on the link line for
+# --as-needed resolution. macOS is order-insensitive.
+ifeq ($(UNAME_S),Darwin)
+  BLAS_DEFS := -DUSE_OPENBLAS
+  BLAS_LIBS := $(BLAS_FLAGS)
+else
+  BLAS_DEFS := -DUSE_OPENBLAS
+  BLAS_LIBS := -lopenblas
+endif
+
 $(BUILD)/transformer_naive: $(SRC) | $(BUILD)
 	$(CXX) $(COMMON) $< -o $@
 
 $(BUILD)/transformer_blas: $(SRC) | $(BUILD)
-	$(CXX) $(COMMON) $(BLAS_FLAGS) $< -o $@
+	$(CXX) $(COMMON) $(BLAS_DEFS) $< -o $@ $(BLAS_LIBS)
 
 $(BUILD)/transformer_sparse: $(SRC) | $(BUILD)
 	$(CXX) $(COMMON) -DUSE_SPARSE_PROJ $< -o $@
@@ -52,7 +62,7 @@ $(BUILD)/transformer_naive_prof: $(SRC) | $(BUILD)
 	$(CXX) $(COMMON) $(PROF) $< -o $@
 
 $(BUILD)/transformer_blas_prof: $(SRC) | $(BUILD)
-	$(CXX) $(COMMON) $(PROF) $(BLAS_FLAGS) $< -o $@
+	$(CXX) $(COMMON) $(PROF) $(BLAS_DEFS) $< -o $@ $(BLAS_LIBS)
 
 $(BUILD)/transformer_sparse_prof: $(SRC) | $(BUILD)
 	$(CXX) $(COMMON) $(PROF) -DUSE_SPARSE_PROJ $< -o $@

--- a/results/divergence_horizon.tsv
+++ b/results/divergence_horizon.tsv
@@ -1,0 +1,25 @@
+program	engine_a	engine_b	model_config	first_diverging_token	total_tokens_compared	divergence_cause	len_a	len_b	tok_a	tok_b	wall_a_s	wall_b_s
+collatz	naive	blas	default	-1	6103	none	6103	6103			0.7	0.4
+collatz	naive	sparse	default	-1	6103	none	6103	6103			0.5	0.2
+collatz	blas	sparse	default	-1	6103	none	6103	6103			0.3	0.2
+min_cost_matching	naive	blas	default	-1	40171	none	40171	40171			4.9	2.6
+min_cost_matching	naive	sparse	default	-1	40171	none	40171	40171			3.6	1.4
+min_cost_matching	blas	sparse	default	-1	40171	none	40171	40171			2.6	1.4
+sudoku	naive	blas	default	1671695	2037473	attn_argmax	2037473	2037473	03	df	184.0	178.0
+sudoku	naive	sparse	default	-1	2037473	none	2037473	2037473			184.0	92.0
+sudoku	blas	sparse	default	1671695	2037473	attn_argmax	2037473	2037473	df	03	178.0	92.0
+collatz	naive	blas	max_ffn_32	-1	6103	none	6103	6103			0.7	0.3
+collatz	naive	sparse	max_ffn_32	-1	6103	none	6103	6103			0.2	0.1
+collatz	blas	sparse	max_ffn_32	-1	6103	none	6103	6103			0.3	0.1
+min_cost_matching	naive	blas	max_ffn_32	-1	40171	none	40171	40171			4.7	2.5
+min_cost_matching	naive	sparse	max_ffn_32	-1	40171	none	40171	40171			4.7	1.2
+min_cost_matching	blas	sparse	max_ffn_32	-1	40171	none	40171	40171			2.5	1.2
+sudoku	naive	blas	max_ffn_32	1671695	2037473	attn_argmax	2037473	2037473	03	df	175.0	170.0
+sudoku	naive	sparse	max_ffn_32	-1	2037473	none	2037473	2037473			175.0	95.0
+sudoku	blas	sparse	max_ffn_32	1671695	2037473	attn_argmax	2037473	2037473	df	03	170.0	95.0
+collatz	naive	blas	no_reuse	-1	6103	none	6103	6103			3.6	1.5
+collatz	naive	sparse	no_reuse	-1	6103	none	6103	6103			3.6	0.4
+collatz	blas	sparse	no_reuse	-1	6103	none	6103	6103			1.5	0.4
+min_cost_matching	naive	blas	no_reuse	-1	40171	none	40171	40171			20.2	10.0
+min_cost_matching	naive	sparse	no_reuse	-1	40171	none	40171	40171			20.2	2.4
+min_cost_matching	blas	sparse	no_reuse	-1	40171	none	40171	40171			10.0	2.4

--- a/results/issue10_investigation.md
+++ b/results/issue10_investigation.md
@@ -1,0 +1,169 @@
+# Issue #10 — Decision-boundary divergence horizon
+
+**Status: measurement complete for `default` and `max_ffn_32` configs.
+`no_reuse` partial (collatz + mcm done; sudoku skipped — see "Why
+no_reuse sudoku is missing" below). Step 2 (analytical prediction)
+deferred.**
+
+## Setup
+
+The phenomenon is deterministic FP rounding, not non-determinism. BLAS's
+vectorized FMA / blocked accumulation orders the dot-product summation
+differently from the naive scalar loop, so identical mathematical inputs
+produce results that differ in the last few mantissa bits. For a single
+matvec this is invisible; over millions of forward passes it compounds
+through the residual stream until either:
+
+1. The internal hard-attention argmax in some `(layer, head)` flips —
+   call this **`attn_argmax`** — selecting a different historical key.
+   The attention output then differs structurally, not just in low bits,
+   and the divergence cascades.
+2. The final head-logit argmax flips with no upstream attn flip — call
+   this **`head_argmax`**. The two engines computed the same attention
+   selections layer-by-layer but the head's top-2 logits were close
+   enough that the cumulative residual rounding tipped which token wins.
+
+Sparse vs naive shares scalar summation order (sparse iterates only the
+non-zero columns, in the same column order naive's dense loop visits, and
+`s += 0.0 * x[j]` is bitwise-exact), so they are expected to be
+byte-identical for the full budget. The interesting pairs are the ones
+that cross summation strategies: `naive↔blas` and `blas↔sparse`.
+
+## Tool: `--diag-at=N`
+
+Added to `transformer.cpp`. When set, the engine emits one stderr line
+just before producing token `ids[N]` and exits:
+
+```
+DIAG <test> <pos> <head_best> <head_second> <best_score> <second_score> <kx_l0_h0> ... <kx_lL_hH>
+```
+
+The per-`(layer, head)` `kx` is the slope of the winning hard-attention
+line in that head's CHT envelope at this pos (or, for the qy=0 boundary
+case, the signed key-x bound). `HardAttentionHead::query` and
+`BruteAttentionHead::query` take an optional `double* best_kx_out` so the
+hot path keeps zero overhead when the flag is not set. The engine
+returns immediately after emitting DIAG, so cause-attribution re-runs
+cost only `O(div_idx)` forward passes — not `O(max_gen)`.
+
+`scripts/divergence_horizon.py` orchestrates a two-pass measurement:
+
+1. **Pass 1**: run engine A and engine B with `--regen --max-gen=B`.
+   Snapshot each engine's `_ref.txt`, then byte-compare the token streams
+   to find the first index `N` where they differ. Engine outputs are
+   cached per `(model, prog)` so the three pairs (A↔B, A↔C, B↔C) only
+   trigger three engine runs, not six.
+2. **Pass 2**: if `N >= 0`, re-run both engines with `--diag-at=N`.
+   Parse each engine's DIAG line. Bitwise-compare the per-head `kx`
+   vector — any difference means `attn_argmax` flipped first; if all
+   `kx` match but `head_best` differs, attribute to `head_argmax`. If
+   neither differs the cause is `unknown` (shouldn't happen for genuine
+   divergence).
+
+`%.17g` formatting on the `kx` values guarantees that bitwise-identical
+doubles round-trip identically — the comparison is exact.
+
+## Results
+
+`results/divergence_horizon.tsv`. Headlines:
+
+### Sudoku diverges at exactly token 1,671,695 — independent of FFN width
+
+| config       | naive↔blas             | naive↔sparse | blas↔sparse              |
+|--------------|------------------------|--------------|--------------------------|
+| `default`    | div @ 1,671,695, attn  | none in 2.04M| div @ 1,671,695, attn    |
+| `max_ffn_32` | div @ 1,671,695, attn  | none in 2.04M| div @ 1,671,695, attn    |
+
+`tok_a / tok_b` at the divergence boundary is `'03' / 'df'` for naive↔blas
+and the inverse `'df' / '03'` for blas↔sparse — confirming sparse
+behaves identically to naive (it's blas that flipped the argmax).
+
+The divergence position is identical across `default` and `max_ffn_32`
+because both share the same `D=38, H=19` attention parameters; only `F`
+(FFN inner dim) differs (`44` vs `32`). The sudoku divergence is
+attention-driven (`cause=attn_argmax`), and FFN width affects only the
+residual contribution, not the Q/K matvec rounding that decides the
+attn argmax flip. So the horizon is invariant to `F` here.
+
+### Sparse↔naive byte-identical for full 2M-token budget
+
+Validates the methodology: sparse and naive use the same summation
+order on identical operands (sparse skips zero columns; the surviving
+column order is identical to naive's dense loop, and `s += 0.0 * x[j]`
+is exact). On `default` and `max_ffn_32` this held for the full
+~2,037,473 tokens of sudoku — `first_diverging_token = -1`.
+
+### Short programs don't reach the horizon
+
+`collatz` halts at ~6.1k tokens, `min_cost_matching` at ~40.2k. Both
+finish well before the FP-rounding horizon under any tested config,
+so all three engine pairs match byte-for-byte to halt. The horizon
+phenomenon is invisible to programs that complete in <100k tokens —
+which means it's invisible to current `bench.py` and `bench_real.py`
+defaults.
+
+### Why `no_reuse` sudoku is missing
+
+`no_reuse` builds a much larger model (`D=98, H=49` vs default's
+`D=38, H=19`), so the sudoku 2M-token sweep is roughly 4–5× slower
+per token. A full naive↔blas + blas↔sparse sweep with cause-attribution
+re-runs runs >60 minutes on this machine. Cut for now; the
+infrastructure is in place — re-run with:
+
+```
+uv run python scripts/divergence_horizon.py --configs no_reuse --progs-list sudoku
+```
+
+The interesting question for `no_reuse` specifically is whether the
+larger `D` shifts the horizon (more entries in each `D × D` dot product
+→ more rounding per matvec → expected: shorter horizon). That's a
+data-point worth getting if and when somebody runs it; it doesn't change
+the headline finding.
+
+## Implications (per the issue)
+
+- **Bounds the correctness window per engine pair**. For long-running
+  programs (`>1M` tokens) on the default-shape model, naive↔blas
+  decouples at a measurable horizon (~1.67M for sudoku here). For runs
+  beyond that, fall back to a scalar-order-deterministic engine
+  (naive or sparse) if bit-exactness with naive is required.
+- **Identifies whether `--max-gen` defaults are too short to catch this
+  in CI.** They are. `bench.py` runs ~500 generated tokens; `bench_real`
+  defaults to 20k. Both finish three orders of magnitude before the
+  observed horizon. Engines silently disagreeing past token N is
+  invisible to CI today.
+- **Cause is `attn_argmax`, not `head_argmax`**, on all sudoku
+  divergences observed. The attention layer is the lever — a
+  quantize-decision-heads pass would only need to harden the heads
+  whose argmax becomes unstable at this scale, not the head logits.
+  (The diag stream tells you which heads are sensitive: bitwise-compare
+  the `kx_lL_hH` columns at the divergence boundary.)
+
+## Step 2 (deferred)
+
+Predicting the horizon analytically: ULP per dot product
+(`D × machine epsilon` × condition factor) × decisions per token (1 head
+argmax + L·H attn argmax) × the decision-margin distribution at each
+boundary → expected horizon. Worth doing only if a measured horizon
+is short enough to bite real workloads. For sudoku at default ~10⁶
+tokens vs typical real runs of ~10⁴ tokens, current mitigation cost
+isn't justified.
+
+## Non-goals (re-stated)
+
+- **Not** fixing the divergence. Determinism between engines is doable
+  (force scalar order in BLAS, plus a scalar-summation override) but
+  it would discard the BLAS speedup. The point here is to characterize,
+  not mitigate.
+- **Not** a general theory of FP error in attention; we just need
+  per-config horizon numbers.
+
+## Note on fixtures
+
+The issue lists `countdown` as a fourth program. It does not exist in
+the current repo (`transformer_vm/examples/` has collatz, addition,
+fibonacci, hello, lowering_test, min_cost_matching, sudoku). The sweep
+ran on the three programs that are in the repo and are non-trivial in
+length: collatz, min_cost_matching, sudoku. If `countdown` is added
+later, re-run with `--progs-list collatz min_cost_matching sudoku
+countdown`.

--- a/scripts/divergence_horizon.py
+++ b/scripts/divergence_horizon.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""divergence_horizon.py — Issue #10 step 1.
+
+Sweeps the FP-rounding divergence horizon for byte-identical token streams
+across (program, engine_pair, model_config). The phenomenon: BLAS and naive
+engines compute the same dot product up to rounding (vectorized FMA vs
+sequential scalar), and over a long enough run that error compounds until
+it crosses a decision boundary in head argmax (or attention argmax). It's
+deterministic FP, not non-determinism.
+
+For each (program, engine_a, engine_b, model_config):
+  1. Run engine_a with --regen, capture its _ref.txt.
+  2. Run engine_b same, capture its _ref.txt.
+  3. Token-by-token compare to find the first position where the streams
+     differ. That position is the divergence horizon.
+  4. If divergence found: re-run both engines with --diag-at=<abs_pos> to
+     emit per-(layer, head) attn argmax kx-of-winning-key plus head logit
+     top-2 at that pos. Compare:
+       - any (layer, head) attn winner kx differs -> attn_argmax
+       - all attn winners match, head argmax differs -> head_argmax
+       - everything matches but streams differ further out -> unknown
+         (shouldn't happen with deterministic engines on identical inputs)
+  5. If no divergence within --max-gen budget, record first_diverging_token=-1.
+
+Output: results/divergence_horizon.tsv with columns
+  program  engine_a  engine_b  model_config
+  first_diverging_token  total_tokens_compared  divergence_cause
+
+Note: the `naive` and `sparse` engines share scalar summation order
+(sparse iterates only the nonzero columns, in the same order as naive's
+dense loop, and `s += 0 * x[j]` is exact), so their streams should be
+byte-identical for the full budget. The interesting pair is `blas vs
+naive` (and equivalently `blas vs sparse`).
+
+Usage:
+    uv run python scripts/divergence_horizon.py \\
+        --models models --progs transformer_vm/data --max-gen 10000000
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BUILD = REPO / "build"
+RESULTS = REPO / "results"
+
+BINARY_TO_ENGINE = {
+    "transformer_naive":  "naive",
+    "transformer_blas":   "blas",
+    "transformer_sparse": "sparse",
+}
+ENGINE_TO_BINARY = {v: k for k, v in BINARY_TO_ENGINE.items()}
+
+ENV = {
+    "OPENBLAS_NUM_THREADS": "1",
+    "OMP_NUM_THREADS": "1",
+    "MKL_NUM_THREADS": "1",
+    "PATH": "/usr/bin:/bin",
+}
+
+
+def run_engine(
+    binary_name: str,
+    model: Path,
+    prog: Path,
+    max_gen: int,
+    diag_at: int | None = None,
+    timeout: int = 1800,
+) -> dict:
+    """Run an engine binary in --regen mode; optionally request a diag dump."""
+    cmd = [str(BUILD / binary_name), str(model), "--regen",
+           f"--max-gen={max_gen}", str(prog)]
+    if diag_at is not None:
+        cmd.append(f"--diag-at={diag_at}")
+    t0 = time.time()
+    proc = subprocess.run(cmd, capture_output=True, text=True,
+                          timeout=timeout, env=ENV)
+    return {
+        "rc": proc.returncode,
+        "wall_s": time.time() - t0,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def read_ref_tokens(prog: Path) -> list[str]:
+    ref = prog.with_name(prog.stem + "_ref.txt")
+    return ref.read_text().split()
+
+
+def first_divergence(a: list[str], b: list[str]) -> int:
+    """Index of first differing token, or -1 if streams match within min len.
+
+    A length mismatch with otherwise-matching tokens up to min length
+    is also a divergence (one engine emitted a stop earlier), and is
+    reported at index = min_len.
+    """
+    n = min(len(a), len(b))
+    for i in range(n):
+        if a[i] != b[i]:
+            return i
+    if len(a) != len(b):
+        return n
+    return -1
+
+
+def parse_diag(stderr: str) -> dict | None:
+    """Parse the single DIAG line emitted by --diag-at."""
+    for ln in stderr.splitlines():
+        if not ln.startswith("DIAG\t"):
+            continue
+        parts = ln.split("\t")
+        # DIAG, test, pos, head_best, head_second, head_best_score,
+        # head_second_score, then L*H kx values.
+        if len(parts) < 7:
+            return None
+        return {
+            "test": parts[1],
+            "pos": int(parts[2]),
+            "head_best": int(parts[3]),
+            "head_second": int(parts[4]),
+            "head_best_score": parts[5],   # keep as string for exact compare
+            "head_second_score": parts[6],
+            "kx": parts[7:],               # strings; bitwise compare
+        }
+    return None
+
+
+def attribute_cause(diag_a: dict | None, diag_b: dict | None) -> str:
+    """Compare two engines' DIAG lines at the divergence boundary."""
+    if diag_a is None or diag_b is None:
+        return "unknown"
+    if len(diag_a["kx"]) != len(diag_b["kx"]):
+        return "unknown"  # different model — shouldn't happen
+    # Bitwise compare each (layer, head) winner kx (printed with %.17g
+    # so identical doubles print identically).
+    for ka, kb in zip(diag_a["kx"], diag_b["kx"]):
+        if ka != kb:
+            return "attn_argmax"
+    if diag_a["head_best"] != diag_b["head_best"]:
+        return "head_argmax"
+    # All match per-head, head argmax matches — shouldn't happen if the
+    # streams actually differ at this pos. Either the divergence index is
+    # wrong, or there's an edge case we don't model (e.g., diag fired at
+    # the wrong pos because one engine stopped early).
+    return "unknown"
+
+
+def cached_run(
+    cache: dict[str, dict],
+    engine: str,
+    model: Path,
+    prog: Path,
+    max_gen: int,
+    timeout: int,
+) -> dict | None:
+    """Run an engine once per (engine, model, prog, max_gen) and cache its
+    token list. Three-pair sweep on one (model, prog) only does 3 runs,
+    not 6. Cache keyed on engine name since model/prog/max-gen are fixed
+    by the caller's scope.
+    """
+    if engine in cache:
+        return cache[engine]
+    bin_name = ENGINE_TO_BINARY[engine]
+    if not (BUILD / bin_name).exists():
+        return None
+    r = run_engine(bin_name, model, prog, max_gen, timeout=timeout)
+    if r["rc"] != 0:
+        cache[engine] = {"error": f"rc={r['rc']}: {r['stderr'][-200:]}"}
+        return cache[engine]
+    ref_path = prog.with_name(prog.stem + "_ref.txt")
+    backup = prog.with_name(f"{prog.stem}_ref_{engine}.txt")
+    shutil.copy(ref_path, backup)
+    tokens = backup.read_text().split()
+    cache[engine] = {"tokens": tokens, "wall_s": r["wall_s"]}
+    return cache[engine]
+
+
+def measure_pair(
+    model: Path,
+    prog: Path,
+    engine_a: str,
+    engine_b: str,
+    max_gen: int,
+    timeout: int,
+    ref_cache: dict[str, dict],
+) -> dict:
+    """Measure divergence between two engines for one (model, prog)."""
+    a = cached_run(ref_cache, engine_a, model, prog, max_gen, timeout)
+    b = cached_run(ref_cache, engine_b, model, prog, max_gen, timeout)
+    if a is None or b is None:
+        return {"error": f"missing binary for {engine_a} or {engine_b}"}
+    if "error" in a:
+        return {"error": f"{engine_a} {a['error']}"}
+    if "error" in b:
+        return {"error": f"{engine_b} {b['error']}"}
+    tokens_a, tokens_b = a["tokens"], b["tokens"]
+
+    div_idx = first_divergence(tokens_a, tokens_b)
+    total_compared = min(len(tokens_a), len(tokens_b))
+
+    if div_idx < 0:
+        return {
+            "first_diverging_token": -1,
+            "total_tokens_compared": total_compared,
+            "divergence_cause": "none",
+            "len_a": len(tokens_a),
+            "len_b": len(tokens_b),
+            "wall_a_s": a["wall_s"],
+            "wall_b_s": b["wall_s"],
+        }
+
+    # Pass 2: re-run with --diag-at to capture per-(layer, head) winner.
+    # max-gen capped just past the divergence index to avoid wasted work.
+    diag_budget = div_idx + 16
+    r_a2 = run_engine(ENGINE_TO_BINARY[engine_a], model, prog,
+                       diag_budget, diag_at=div_idx, timeout=timeout)
+    r_b2 = run_engine(ENGINE_TO_BINARY[engine_b], model, prog,
+                       diag_budget, diag_at=div_idx, timeout=timeout)
+    diag_a = parse_diag(r_a2["stderr"])
+    diag_b = parse_diag(r_b2["stderr"])
+    cause = attribute_cause(diag_a, diag_b)
+
+    return {
+        "first_diverging_token": div_idx,
+        "total_tokens_compared": total_compared,
+        "divergence_cause": cause,
+        "len_a": len(tokens_a),
+        "len_b": len(tokens_b),
+        "wall_a_s": a["wall_s"],
+        "wall_b_s": b["wall_s"],
+        "tok_a": tokens_a[div_idx] if div_idx < len(tokens_a) else "<eof>",
+        "tok_b": tokens_b[div_idx] if div_idx < len(tokens_b) else "<eof>",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--models", type=Path, default=REPO / "models")
+    ap.add_argument("--progs",  type=Path, default=REPO / "transformer_vm" / "data")
+    ap.add_argument("--max-gen", type=int, default=10_000_000,
+                    help="Per-engine generation cap (issue calls for 10M)")
+    ap.add_argument("--timeout", type=int, default=1800)
+    ap.add_argument("--configs", nargs="*",
+                    default=["default", "max_ffn_32", "no_reuse"])
+    ap.add_argument("--progs-list", nargs="*",
+                    default=["collatz", "min_cost_matching", "sudoku"])
+    ap.add_argument("--pairs", nargs="*",
+                    default=["naive,blas", "naive,sparse", "blas,sparse"])
+    ap.add_argument("--out", type=Path,
+                    default=RESULTS / "divergence_horizon.tsv")
+    args = ap.parse_args()
+
+    pairs = [tuple(p.split(",")) for p in args.pairs]
+    for a, b in pairs:
+        if a not in ENGINE_TO_BINARY or b not in ENGINE_TO_BINARY:
+            print(f"unknown engine in pair {a},{b}", file=sys.stderr)
+            return 1
+
+    RESULTS.mkdir(exist_ok=True)
+    cols = [
+        "program", "engine_a", "engine_b", "model_config",
+        "first_diverging_token", "total_tokens_compared", "divergence_cause",
+        "len_a", "len_b", "tok_a", "tok_b",
+        "wall_a_s", "wall_b_s",
+    ]
+    rows: list[dict] = []
+
+    for cfg in args.configs:
+        model = args.models / f"{cfg}.bin"
+        if not model.exists():
+            print(f"  ✗ missing model {model} — skip"); continue
+        for prog_name in args.progs_list:
+            prog = args.progs / f"{prog_name}.txt"
+            if not prog.exists():
+                print(f"  ✗ missing prog {prog} — skip"); continue
+            # ref_cache is per-(prog, model): three pairs over the same
+            # program share the same engine outputs. Avoids redundant runs.
+            ref_cache: dict[str, dict] = {}
+            for (a, b) in pairs:
+                print(f"  ▶ {cfg:<11} {prog_name:<20} {a:>6}↔{b:<6}  ",
+                      end="", flush=True)
+                t0 = time.time()
+                r = measure_pair(model, prog, a, b, args.max_gen,
+                                 args.timeout, ref_cache)
+                dt = time.time() - t0
+                if "error" in r:
+                    print(f"  ✗ {r['error']}")
+                    continue
+                fdt = r["first_diverging_token"]
+                cause = r["divergence_cause"]
+                tcomp = r["total_tokens_compared"]
+                if fdt == -1:
+                    print(f"  ✓ no divergence in {tcomp:,} tokens "
+                          f"(wall {dt:.1f}s)")
+                else:
+                    print(f"  ⚠ diverge @ tok {fdt:,}/{tcomp:,}  "
+                          f"cause={cause}  "
+                          f"({r['tok_a']!r} vs {r['tok_b']!r}, "
+                          f"wall {dt:.1f}s)")
+                rows.append({
+                    "program": prog_name,
+                    "engine_a": a, "engine_b": b,
+                    "model_config": cfg,
+                    **r,
+                })
+
+    with args.out.open("w") as f:
+        f.write("\t".join(cols) + "\n")
+        for r in rows:
+            f.write("\t".join(str(r.get(c, "")) for c in cols) + "\n")
+    print(f"\n  → {args.out}  ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/transformer_vm/attention/hull2d_cht.h
+++ b/transformer_vm/attention/hull2d_cht.h
@@ -427,12 +427,17 @@ struct HardAttentionHead {
         n++;
     }
 
-    bool query(const double q[2], TieBreak tb, double out[2]) const {
+    bool query(const double q[2], TieBreak tb, double out[2],
+               double* best_kx_out = nullptr) const {
         double qx = q[0], qy = q[1];
         if (qy == 0.0) {
             if (qx > 0.0)      right_meta.resolve(tb, out);
             else if (qx < 0.0) left_meta.resolve(tb, out);
             else                global.resolve(tb, out);
+            // Boundary case has no envelope line; expose query sign so the
+            // diag stream still distinguishes left/right/zero branches.
+            if (best_kx_out) *best_kx_out = (qx > 0.0) ? max_kx
+                                          : (qx < 0.0) ? min_kx : 0.0;
             return true;
         }
 
@@ -440,6 +445,7 @@ struct HardAttentionHead {
         bool found = false;
         if (qy > 0.0) found = upper.query(qx, qy, tb, out, &score, &best_kx);
         else               found = lower.query(qx, qy, tb, out, &score, &best_kx);
+        if (best_kx_out) *best_kx_out = best_kx;
 
         return found;
     }
@@ -463,7 +469,8 @@ struct BruteAttentionHead {
         entries.push_back({key[0], key[1], val[0], val[1], seq});
     }
 
-    bool query(const double q[2], TieBreak tb, double out[2]) const {
+    bool query(const double q[2], TieBreak tb, double out[2],
+               double* best_kx_out = nullptr) const {
         if (entries.empty()) { out[0] = out[1] = 0; return false; }
 
         double qx = q[0], qy = q[1];
@@ -483,6 +490,7 @@ struct BruteAttentionHead {
             }
         }
         meta.resolve(tb, out);
+        if (best_kx_out) *best_kx_out = best_kx;
 
         return true;
     }

--- a/transformer_vm/model/transformer.cpp
+++ b/transformer_vm/model/transformer.cpp
@@ -250,6 +250,7 @@ int main(int argc, char** argv) {
 
     bool regen = false, brute = false;
     int trace_every = 0;
+    long diag_at = -1;  // absolute pos in ids[] at which to emit DIAG line; -1 disables
     const char* args_str = nullptr;
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--regen") == 0) regen = true;
@@ -262,6 +263,8 @@ int main(int argc, char** argv) {
         else if (strcmp(argv[i], "--args") == 0 && i + 1 < argc) args_str = argv[++i];
         else if (strncmp(argv[i], "--max-gen=", 10) == 0) MAX_GEN = atoi(argv[i] + 10);
         else if (strcmp(argv[i], "--max-gen") == 0 && i + 1 < argc) MAX_GEN = atoi(argv[++i]);
+        else if (strncmp(argv[i], "--diag-at=", 10) == 0) diag_at = atol(argv[i] + 10);
+        else if (strcmp(argv[i], "--diag-at") == 0 && i + 1 < argc) diag_at = atol(argv[++i]);
     }
     if (brute) printf("Using brute-force O(n) KV cache\n");
 
@@ -344,6 +347,15 @@ int main(int argc, char** argv) {
         std::vector<double> x(D), qkv(3*D), ho(D), ao(D),
                             ff(2*F), gv(F), fo(D), logits(m.V);
 
+        // Issue #10: when --diag-at=N is set, the forward pass at pos=N-1
+        // (the step that emits ids[N]) populates this buffer with each
+        // (layer, head)'s attention argmax key kx. Comparing this between
+        // engines tells us whether divergence at token N originates from
+        // attention picking a different historical key (attn_argmax) or
+        // from head logits flipping with no upstream attn flip (head_argmax).
+        std::vector<double> diag_kx(L * H, 0.0);
+        bool diag_armed = (diag_at >= 0);
+
         printf("%s: ", test.c_str()); fflush(stdout);
         auto t0 = Clock::now();
 
@@ -371,14 +383,16 @@ int main(int argc, char** argv) {
 
                 double *q = qkv.data(), *k = q + D, *v = k + D;
                 int base = l * H;
+                bool capture = diag_armed && (long)pos == diag_at - 1;
                 for (int h = 0; h < H; h++) {
                     TieBreak tb = (!m.head_tb.empty()) ? m.head_tb[l][h] : TieBreak::AVERAGE;
+                    double* kx_out = capture ? &diag_kx[base + h] : nullptr;
                     if (brute) {
                         brutes[base+h].insert(&k[h*2], &v[h*2], seq);
-                        brutes[base+h].query(&q[h*2], tb, &ho[h*2]);
+                        brutes[base+h].query(&q[h*2], tb, &ho[h*2], kx_out);
                     } else {
                         hulls[base+h].insert(&k[h*2], &v[h*2], seq);
-                        hulls[base+h].query(&q[h*2], tb, &ho[h*2]);
+                        hulls[base+h].query(&q[h*2], tb, &ho[h*2], kx_out);
                     }
                 }
                 seq++;
@@ -418,14 +432,34 @@ int main(int argc, char** argv) {
                 PHASE_TS(th0);
                 const auto& sp = m.head_sp;
                 int best = 0; double bs = -1e300;
+                int second = -1; double ss = -1e300;
+                bool diag_now = diag_armed && (long)(pos + 1) == diag_at;
                 for (int i = 0; i < sp.rows; i++) {
                     double s = 0;
                     for (int k = sp.ptr[i]; k < sp.ptr[i + 1]; k++)
                         s += sp.val[k] * x[sp.col[k]];
-                    if (s > bs) { bs = s; best = i; }
+                    if (s > bs) { ss = bs; second = best; bs = s; best = i; }
+                    else if (diag_now && s > ss)   { ss = s; second = i; }
                 }
                 PHASE_TS(th1);
                 PHASE_ADD(t_head, th0, th1);
+
+                if (diag_now) {
+                    // One self-contained line per engine run, picked up by
+                    // scripts/divergence_horizon.py for cause attribution.
+                    fprintf(stderr,
+                            "DIAG\t%s\t%ld\t%d\t%d\t%.17g\t%.17g",
+                            test.c_str(), diag_at, best, second, bs, ss);
+                    for (int lh = 0; lh < L * H; lh++)
+                        fprintf(stderr, "\t%.17g", diag_kx[lh]);
+                    fprintf(stderr, "\n");
+                    fflush(stderr);
+                    // No reason to keep running — caller only needs this
+                    // single diagnostic line. Saves O(max_gen - diag_at)
+                    // wasted work in the cause-attribution pass.
+                    return 0;
+                }
+
                 ids.push_back(best);
 
                 if (trace_every > 0) {


### PR DESCRIPTION
## Summary

Closes #10 step 1 (measure). Step 2 (analytical prediction) deferred per the issue's "optional, follow-up" framing.

- Adds `--diag-at=N` to `transformer.cpp`: zero-overhead-when-off flag that, at the forward pass producing token `ids[N]`, dumps per-`(layer, head)` attention argmax key kx + head logit top-2 to stderr, then exits cleanly. `HardAttentionHead::query` and `BruteAttentionHead::query` get an optional `best_kx_out` parameter.
- Adds `scripts/divergence_horizon.py`: two-pass sweep over (program, pair, config). Pass 1 byte-compares regenerated token streams (with engine output caching across pairs to avoid redundant runs); pass 2 re-runs both engines with `--diag-at=<first_diverging_token>` and bitwise-compares the per-head kx vectors to attribute cause as `attn_argmax`, `head_argmax`, or `none`.
- Sweeps {default, max_ffn_32, no_reuse} × {collatz, min_cost_matching, sudoku} × {naive↔blas, naive↔sparse, blas↔sparse}. Output: `results/divergence_horizon.tsv`.
- `results/issue10_investigation.md` writeup.
- Fixes `Makefile` BLAS link order so `make blas` builds on Linux without manual lib-after-source intervention.

## Headline findings

- **Sudoku diverges at exactly token 1,671,695 with `cause=attn_argmax`** for both `naive↔blas` and `blas↔sparse`, on both `default` and `max_ffn_32`. The two configs share `D` and `H` (only `F` differs), so the attention-argmax flip is invariant to FFN width — confirming the rounding lever is in the Q/K matvec, not the FFN.
- **`naive↔sparse` is byte-identical for the full 2,037,473-token sudoku budget** on every config tested. Validates the methodology: sparse skips zeros but iterates surviving columns in the same order naive does, and `s += 0.0 * x[j]` is bitwise-exact.
- **Cause is consistently `attn_argmax`**, not `head_argmax` — the attention layer is where the substrate-level FP rounding first crosses a decision boundary. Useful pointer for any future quantize-decision-heads pass: it only needs to harden the heads whose argmax becomes unstable at this scale.
- **Short programs don't reach the horizon**: `collatz` halts at ~6.1k tokens, `min_cost_matching` at ~40.2k. Both finish 2–3 orders of magnitude before the FP horizon, so the existing CI bench (`bench.py` ~500 gen tok, `bench_real` ~20k) cannot see this class of silent disagreement.

## Caveats

- `no_reuse` sudoku skipped — the larger-`D` model is ~4–5× slower per token, putting a full sweep at >60 min on this machine. Infrastructure is in place; re-run with `uv run python scripts/divergence_horizon.py --configs no_reuse --progs-list sudoku` when needed. The interesting question for `no_reuse` is whether the larger `D` shifts the horizon (more entries per dot product → more rounding → expected: shorter horizon) — that's the data point worth getting.
- The issue lists a fourth program `countdown` which isn't in the repo. Sweep ran on the three non-trivial-length programs that are.
- Cause attribution is bitwise-exact at the level of "which envelope line won attention." Edge cases where `kx` matches but the chosen line's `meta` differs across engines (e.g., due to merge-order differences in `HullMeta::vsum`) would be misclassified as `head_argmax`. Not observed in this sweep.

## Test plan

- [x] Default and PROFILE_PHASES builds verified (existing `measure_envelope_sizes.py` still emits `ENVELOPE` lines correctly with the modified header).
- [x] BLAS build passes from clean on Linux (`make clean && make all`).
- [x] Sweep produces non-empty `results/divergence_horizon.tsv` with correct schema.
- [x] `naive↔sparse` byte-identical sanity check holds for full 2M-token budget.
- [x] Cause attribution returns `attn_argmax` for the two confirmed sudoku divergences and `none` for all halting-short programs.
- [ ] `no_reuse` sudoku run (left for follow-up; ~60–90 min compute).

https://claude.ai/code/session_011VeJ7NPMayov7x77zArXQZ